### PR TITLE
TS-28 - adding wfh event and hook up endpoint

### DIFF
--- a/src/components/Booking/EventTypeGroup/index.js
+++ b/src/components/Booking/EventTypeGroup/index.js
@@ -16,10 +16,10 @@ class EventTypeGroup extends Component {
       eventType: [
         { type: type.ANNUAL_LEAVE, icon: 'suitcase', color: '#A7BF35' },
         { type: type.WFH, icon: 'home', color: '#399BB6' },
-        { type: 'Sick leave', icon: 'bed', color: '#A2798F' },
-        { type: 'Work related travel', icon: 'plane', color: '#FF544E' },
+        { type: type.SICK_LEAVE, icon: 'bed', color: '#A2798F' },
+        { type: type.WORK_TRAVEL, icon: 'plane', color: '#FF544E' },
       ],
-      selectedIndex: '',
+      selectedIndex: 0,
     };
   }
 

--- a/src/components/Booking/EventTypeGroup/index.js
+++ b/src/components/Booking/EventTypeGroup/index.js
@@ -1,23 +1,33 @@
 import React, { Component } from 'react';
 import { View, StyleSheet, Text, TouchableOpacity } from 'react-native';
+import { PropTypes as PT } from 'prop-types';
 import { Icon } from 'react-native-elements';
 import { GREY, WHITE } from '../../../styles/colors';
+import type from '../../../constants/eventTypes';
 
 class EventTypeGroup extends Component {
+  static propTypes = {
+    selectEventType: PT.func.isRequired,
+  }
+
   constructor() {
     super();
     this.state = {
       eventType: [
-        { type: 'Annual leave', icon: 'suitcase', color: '#A7BF35' },
-        { type: 'Working from Home', icon: 'home', color: '#399BB6' },
+        { type: type.ANNUAL_LEAVE, icon: 'suitcase', color: '#A7BF35' },
+        { type: type.WFH, icon: 'home', color: '#399BB6' },
         { type: 'Sick leave', icon: 'bed', color: '#A2798F' },
         { type: 'Work related travel', icon: 'plane', color: '#FF544E' },
       ],
-      selectedIndex: 0,
+      selectedIndex: '',
     };
   }
 
-  selected = i => this.setState({ selectedIndex: i });
+  selected = (i, eventType) => {
+    const { selectEventType } = this.props;
+    this.setState({ selectedIndex: i });
+    selectEventType(eventType[i].type);
+  };
 
   render() {
     const { eventType, selectedIndex } = this.state;
@@ -28,7 +38,7 @@ class EventTypeGroup extends Component {
       return (
         <TouchableOpacity
           key={index}
-          onPress={() => this.selected(index)}
+          onPress={() => this.selected(index, eventType)}
           style={[styles.box,
             {
               backgroundColor: isSelected ? event.color : WHITE,

--- a/src/components/Booking/View/index.js
+++ b/src/components/Booking/View/index.js
@@ -24,6 +24,7 @@ const BookingView = (props) => {
     remainingHolidays,
     potentialHolidays,
     eventsLoaded,
+    selectEventType,
   } = props;
 
   const { startDate, endDate, halfDay } = booking;
@@ -40,7 +41,9 @@ const BookingView = (props) => {
               <FormLabel labelStyle={styles.formLabel}>
                 TYPE
               </FormLabel>
-              <EventTypeGroup />
+              <EventTypeGroup
+                selectEventType={selectEventType}
+              />
             </View>
 
             <View>
@@ -127,6 +130,7 @@ BookingView.propTypes = {
   remainingHolidays: PT.number.isRequired,
   potentialHolidays: PT.number.isRequired,
   eventsLoaded: PT.bool.isRequired,
+  selectEventType: PT.func.isRequired,
 };
 
 export default BookingView;

--- a/src/components/Booking/container.js
+++ b/src/components/Booking/container.js
@@ -58,7 +58,7 @@ export default Container => class extends Component {
         endDate: holiday.endDate || chosenDate,
         halfDay: holiday.halfDay,
         duration: holiday.duration,
-        eventType: holiday.eventType,
+        eventType: holiday.eventType === undefined ? eventType.ANNUAL_LEAVE : holiday.eventType,
       },
       booked,
     });

--- a/src/components/Booking/container.js
+++ b/src/components/Booking/container.js
@@ -4,9 +4,11 @@ import { PropTypes as PT } from 'prop-types';
 import moment from 'moment';
 import { userProfile } from '../../utilities/currentUser';
 import { requestHolidays, updateHolidayRequest, cancelHolidayRequest } from '../../services/holidayService';
+import { requestWFH } from '../../services/wfhService';
 import { getUserEvents, getRemainingHolidays } from '../../utilities/holidays';
 import { getDays, getDuration } from '../../utilities/dates';
 import * as eventDescription from '../../constants/eventDescription';
+import eventType from '../../constants/eventTypes';
 
 export default Container => class extends Component {
   static propTypes = {
@@ -26,6 +28,7 @@ export default Container => class extends Component {
         endDate: '',
         halfDay: false,
         duration: 0,
+        eventType: '',
       },
       booked: false,
       user: {},
@@ -55,6 +58,7 @@ export default Container => class extends Component {
         endDate: holiday.endDate || chosenDate,
         halfDay: holiday.halfDay,
         duration: holiday.duration,
+        eventType: holiday.eventType,
       },
       booked,
     });
@@ -62,6 +66,15 @@ export default Container => class extends Component {
 
   componentWillUnmount() {
     this.sub.remove();
+  }
+
+  selectEventType = (type) => {
+    this.setState(prevState => ({
+      booking: {
+        ...prevState.booking,
+        eventType: type,
+      },
+    }));
   }
 
   loadData = () => {
@@ -116,6 +129,11 @@ export default Container => class extends Component {
     const { navigation } = this.props;
     this.setState({ loading: true });
 
+    const endpoints = {
+      [eventType.ANNUAL_LEAVE]: requestHolidays,
+      [eventType.WFH]: requestWFH,
+    };
+
     const request = {
       dates: [
         {
@@ -127,7 +145,7 @@ export default Container => class extends Component {
       employeeId: user.employeeId,
     };
 
-    requestHolidays(request)
+    endpoints[booking.eventType](request)
       .then(() => {
         this.setState({ loading: false });
         navigation.pop();
@@ -210,6 +228,7 @@ export default Container => class extends Component {
         potentialHolidays={potentialHolidays}
         eventsLoaded={eventsLoaded}
         pendingDays={pendingDays}
+        selectEventType={this.selectEventType}
       />
     );
   }

--- a/src/components/Booking/container.js
+++ b/src/components/Booking/container.js
@@ -58,7 +58,7 @@ export default Container => class extends Component {
         endDate: holiday.endDate || chosenDate,
         halfDay: holiday.halfDay,
         duration: holiday.duration,
-        eventType: holiday.eventType === undefined ? eventType.ANNUAL_LEAVE : holiday.eventType,
+        eventType: holiday.eventType || eventType.ANNUAL_LEAVE,
       },
       booked,
     });

--- a/src/components/Home/container.js
+++ b/src/components/Home/container.js
@@ -120,6 +120,7 @@ export default Container => class extends Component {
           status: item.eventStatus.description,
           holId: item.holidayId,
           duration: item.halfDay ? 0.5 : getDuration(item.start, item.end),
+          eventType: item.eventType.description,
         };
       });
 

--- a/src/constants/eventTypes.js
+++ b/src/constants/eventTypes.js
@@ -1,6 +1,8 @@
 const eventType = {
   ANNUAL_LEAVE: 'Annual Leave',
   WFH: 'Working From Home',
+  SICK_LEAVE: 'Sick Leave',
+  WORK_TRAVEL: 'Work related travel',
 };
 
 export default eventType;

--- a/src/constants/eventTypes.js
+++ b/src/constants/eventTypes.js
@@ -1,0 +1,6 @@
+const eventType = {
+  ANNUAL_LEAVE: 'Annual Leave',
+  WFH: 'Working From Home',
+};
+
+export default eventType;

--- a/src/services/wfhService.js
+++ b/src/services/wfhService.js
@@ -1,0 +1,7 @@
+import axios from '../utilities/AxiosInstance';
+
+export const getWFH = employeeId => axios.get(`/workingFromHome/findByEmployeeId/${employeeId}`);
+
+export const requestWFH = dates => axios.post('/workingFromHome/', dates);
+
+export const getWFHById = wfhId => axios.get(`/workingFromHome/${wfhId}`);


### PR DESCRIPTION
commits: 
Just one commit. adding wfh event and hook up endpoint

![screenshot_1540311136](https://user-images.githubusercontent.com/40429630/47375021-392f7100-d6e7-11e8-8e49-615838706b76.png)
![screenshot_1540311145](https://user-images.githubusercontent.com/40429630/47375022-392f7100-d6e7-11e8-881a-b5629acf7cda.png)

endpoint: /workingFromHome/findByEmployeeId/{employeeID}
GET request returns: 

`[
  {
    "eventId": 58,
    "startDate": [
      2018,
      10,
      24
    ],
    "endDate": [
      2018,
      10,
      24
    ],
    "eventStatusId": 1,
    "eventStatusDescription": "Awaiting approval",
    "employee": {
      "employeeId": 8,
      "forename": "homer",
      "surname": "simpson",
      "email": "homer@test.com",
      "totalHolidays": 4,
      "startDate": [
        2018,
        10,
        22
      ],
`

WFH is displayed as 'Awaiting Approval' for the mean time. I will add a story on JIRA to update UI so that we are able to distinguish between annual leave and wfh events .