### PR TITLE
TS-140 - booking wfh does not display warning messages

### DIFF
--- a/src/components/Booking/EventTypeGroup/index.js
+++ b/src/components/Booking/EventTypeGroup/index.js
@@ -8,20 +8,34 @@ import type from '../../../constants/eventTypes';
 class EventTypeGroup extends Component {
   static propTypes = {
     selectEventType: PT.func.isRequired,
+    booked: PT.bool.isRequired,
+    booking: PT.shape({
+      eventType: PT.string,
+    }).isRequired,
   }
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
-      eventType: [
+      eventTypes: [
         { type: type.ANNUAL_LEAVE, icon: 'suitcase', color: '#A7BF35' },
         { type: type.WFH, icon: 'home', color: '#399BB6' },
         { type: type.SICK_LEAVE, icon: 'bed', color: '#A2798F' },
         { type: type.WORK_TRAVEL, icon: 'plane', color: '#FF544E' },
       ],
-      selectedIndex: 0,
+      selectedIndex: this.preSelected(),
     };
   }
+
+  preSelected = () => {
+    const { booking: { eventType } } = this.props;
+    let number = 0;
+    if (eventType === type.WFH) {
+      number = 1;
+    }
+
+    return number;
+  };
 
   selected = (i, eventType) => {
     const { selectEventType } = this.props;
@@ -30,19 +44,22 @@ class EventTypeGroup extends Component {
   };
 
   render() {
-    const { eventType, selectedIndex } = this.state;
-    const checkBox = eventType.map((event, index) => {
+    const { booked, booking: { eventType } } = this.props;
+    const { eventTypes, selectedIndex } = this.state;
+    const checkBox = eventTypes.map((event, index) => {
       const isSelected = selectedIndex === index;
       const isOdd = index % 2 === 1;
 
       return (
         <TouchableOpacity
+          disabled={booked}
           key={index}
-          onPress={() => this.selected(index, eventType)}
+          onPress={() => this.selected(index, eventTypes)}
           style={[styles.box,
             {
               backgroundColor: isSelected ? event.color : WHITE,
               marginRight: isOdd ? 0 : 10,
+              opacity: booked && event.type !== eventType ? 0.4 : 1,
             },
           ]}
         >

--- a/src/components/Booking/EventTypeGroup/index.js
+++ b/src/components/Booking/EventTypeGroup/index.js
@@ -29,12 +29,10 @@ class EventTypeGroup extends Component {
 
   preSelected = () => {
     const { booking: { eventType } } = this.props;
-    let number = 0;
     if (eventType === type.WFH) {
-      number = 1;
+      return 1;
     }
-
-    return number;
+    return 0;
   };
 
   selected = (i, eventType) => {

--- a/src/components/Booking/RequestButton/index.js
+++ b/src/components/Booking/RequestButton/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button } from 'react-native-elements';
 import { PropTypes as PT } from 'prop-types';
 import { UNOBLUE } from '../../../styles/colors';
+import eventTypes from '../../../constants/eventTypes';
 
 const RequestButton = (props) => {
   const {
@@ -14,7 +15,7 @@ const RequestButton = (props) => {
     booking,
   } = props;
 
-  const { duration } = booking;
+  const { duration, eventType } = booking;
   const availableDays = booked
     ? (remainingHolidays - potentialHolidays + duration)
     : (remainingHolidays - potentialHolidays);
@@ -22,7 +23,7 @@ const RequestButton = (props) => {
   return (
     booked ? (
       <Button
-        disabled={(availableDays < 0)}
+        disabled={availableDays < 0}
         onPress={updateHoliday}
         title="Update"
         backgroundColor={UNOBLUE}
@@ -33,8 +34,11 @@ const RequestButton = (props) => {
       />
     ) : (
       <Button
-        disabled={(remainingHolidays <= 0
-          || availableDays < 0)}
+        disabled={eventType !== eventTypes.WFH
+          ? ((remainingHolidays <= 0
+            || availableDays < 0))
+          : false
+        }
         onPress={submitRequest}
         title="Request"
         backgroundColor={UNOBLUE}

--- a/src/components/Booking/RequestButton/index.js
+++ b/src/components/Booking/RequestButton/index.js
@@ -35,7 +35,7 @@ const RequestButton = (props) => {
     ) : (
       <Button
         disabled={eventType !== eventTypes.WFH
-          ? ((remainingHolidays <= 0 || availableDays < 0))
+          ? (remainingHolidays <= 0 || availableDays < 0)
           : false
         }
         onPress={submitRequest}

--- a/src/components/Booking/RequestButton/index.js
+++ b/src/components/Booking/RequestButton/index.js
@@ -35,8 +35,7 @@ const RequestButton = (props) => {
     ) : (
       <Button
         disabled={eventType !== eventTypes.WFH
-          ? ((remainingHolidays <= 0
-            || availableDays < 0))
+          ? ((remainingHolidays <= 0 || availableDays < 0))
           : false
         }
         onPress={submitRequest}

--- a/src/components/Booking/View/index.js
+++ b/src/components/Booking/View/index.js
@@ -97,7 +97,7 @@ const BookingView = (props) => {
               />)
             : null}
 
-          {warningMessage || (!status)
+          {warningMessage || !status
             ? (
               <View style={styles.buttonContainer}>
                 <RequestButton

--- a/src/components/Booking/View/index.js
+++ b/src/components/Booking/View/index.js
@@ -10,6 +10,7 @@ import EventTypeGroup from '../EventTypeGroup';
 import WarningMessage from '../WarningMessage';
 import { UNOBLUE } from '../../../styles/colors';
 import * as eventDescription from '../../../constants/eventDescription';
+import eventTypes from '../../../constants/eventTypes';
 
 const BookingView = (props) => {
   const {
@@ -28,7 +29,9 @@ const BookingView = (props) => {
     selectEventType,
   } = props;
 
-  const { startDate, endDate, halfDay, status } = booking;
+  const { startDate, endDate, halfDay, status, eventType } = booking;
+  const warningMessage = status === eventDescription.REJECTED
+    || status === eventDescription.PENDING;
 
   return (
     eventsLoaded
@@ -44,6 +47,8 @@ const BookingView = (props) => {
                 TYPE
               </FormLabel>
               <EventTypeGroup
+                booked={booked}
+                booking={booking}
                 selectEventType={selectEventType}
               />
             </View>
@@ -82,27 +87,29 @@ const BookingView = (props) => {
             </View>
           </View>
 
-          {!status || status === eventDescription.REJECTED || status === eventDescription.PENDING
+          {warningMessage || (!status && eventType !== eventTypes.WFH)
             ? (
-              <Fragment>
-                <WarningMessage
-                  remainingHolidays={remainingHolidays}
+              <WarningMessage
+                remainingHolidays={remainingHolidays}
+                booked={booked}
+                potentialHolidays={potentialHolidays}
+                booking={booking}
+              />)
+            : null}
+
+          {warningMessage || (!status)
+            ? (
+              <View style={styles.buttonContainer}>
+                <RequestButton
+                  updateHoliday={updateHoliday}
+                  submitRequest={submitRequest}
                   booked={booked}
+                  loading={loading}
+                  remainingHolidays={remainingHolidays}
                   potentialHolidays={potentialHolidays}
                   booking={booking}
                 />
-                <View style={styles.buttonContainer}>
-                  <RequestButton
-                    updateHoliday={updateHoliday}
-                    submitRequest={submitRequest}
-                    booked={booked}
-                    loading={loading}
-                    remainingHolidays={remainingHolidays}
-                    potentialHolidays={potentialHolidays}
-                    booking={booking}
-                  />
-                </View>
-              </Fragment>)
+              </View>)
             : null}
 
         </ScrollView>


### PR DESCRIPTION
Commits: 
- booking wfh does not display warning messages

Booking WFH will not display any warning messages and the request button will always be enabled. 
![screenshot_1541433598](https://user-images.githubusercontent.com/40429630/48010429-7d723680-e115-11e8-907d-f098793b3120.png)

When a WFH is booked, it's event type will be selected. The other event types will be disabled and it will appear grey-ish on the UI. 
![screenshot_1541433606](https://user-images.githubusercontent.com/40429630/48010458-882ccb80-e115-11e8-8641-0cf4cb8dfc30.png)


