### PR TITLE
TS-91 - Prevent user from selecting past dates

### DIFF
--- a/src/components/Home/View/index.js
+++ b/src/components/Home/View/index.js
@@ -24,6 +24,7 @@ const HomeView = (props) => {
     <ScrollView contentContainerStyle={styles.container}>
       <Calendar
         style={[styles.calendar]}
+        minDate={new Date()}
         markedDates={events}
         markingType="period"
         dayComponent={dayProps => <CustomDay {...dayProps} />}


### PR DESCRIPTION
Commits: 
- Prevent user from selecting past dates

User is no longer able to select past dates.  Current date: 07 Nov 2018. The past dates are greyed out. 
![screenshot_1541594437](https://user-images.githubusercontent.com/40429630/48132176-8b959380-e28a-11e8-9d9b-7a8a18c6ec2a.png)
